### PR TITLE
Showcasing capability to adjust ddb's dimension names

### DIFF
--- a/hydro-models/03-model-specific/01_mesh/mesh_flow.ipynb
+++ b/hydro-models/03-model-specific/01_mesh/mesh_flow.ipynb
@@ -107,9 +107,11 @@
     "    },\n",
     "    'ddb_min_values': {\n",
     "        'ChnlSlope': 1e-10,\n",
-    "        'ChnlLength': 1,\n",
-    "        'GridArea': 1,\n",
+    "        'ChnlLength': 1e-3, # unit of this number is based on the `ddb_to_units`\n",
+    "        'GridArea': 1e-3, # unit of this number is based on the `ddb_to_units`\n",
     "    },\n",
+    "    'gru_dim': 'gru', # change to 'NGRU' in MESH>=r1860\n",
+    "    'hru_dim': 'subbasin', # no need to change, only to show case the capability\n",
     "}"
    ]
   },


### PR DESCRIPTION
This PR simply show cases meshflow's latest version (v0.1.0-dev1) capability to adjust the ddb's dimension names. This was deemed necessary as in MESH<r1860 the `gru` dimension could be names `gru`, however, with MESH>=r1860, the dimension name must be in upper case and could be named `GRU` or `NGRU`.

The suggestion is `NGRU` to not be mistaken with the `GRU` variable name.

Reported-by: Kasra Keshavarz <kasra.keshavarz1@ucalgary.ca>